### PR TITLE
Fix import of a courseware after changes to filesystem API in Stud.IP v4.6 

### DIFF
--- a/controllers/block_manager.php
+++ b/controllers/block_manager.php
@@ -561,7 +561,7 @@ class BlockManagerController extends CoursewareStudipController
                                 $remote_file = FileRef::find($file['id']);
 
                                 if ($remote_file != null) {
-                                    $file = FileManager::copyFileRef($remote_file, $import_folder, \User::findCurrent());
+                                    $file = FileManager::copyFile($remote_file->getFiletype(), $import_folder, \User::findCurrent());
 
                                 }
                             }


### PR DESCRIPTION
There were a lot changes to the filesystem API in Stud.IP v4.6 which are now interfering with the import of a previously exported courseware.

This PR fixes virtUOS/courseware#240